### PR TITLE
Update api.js with missing semicolon

### DIFF
--- a/app/routes/api.js
+++ b/app/routes/api.js
@@ -6,4 +6,4 @@ const date = require('../api/date.js');
 
 router.get('/date', date.today);
 
-module.exports = router
+module.exports = router;


### PR DESCRIPTION
A semicolon was  omitted on the last line. Since semicolons are used throughout the project, a semicolon was added to the last line for consistency.